### PR TITLE
Validation Rule: Add support to validate enum key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All Notable changes to `laravel-enum` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [Unreleased]
+
+### Added
+- Add support to validate enum key
+
 ## 1.1.0 - 2018-09-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -165,6 +165,24 @@ public function store(Request $request)
 }
 ```
 
+If you want to validate an enum key instead of an enum value you can by specifying you want to validate against the key 
+instead of the value.
+
+``` php
+public function store(Request $request)
+{
+    $this->validate($request, [
+        'status' => ['required', new EnumRule(PostStatusEnum::class, true)],
+    ]);
+
+    // OR
+
+    $this->validate($request, [
+        'status' => ['required', PostStatusEnum::ruleByKey()],
+    ]);
+}
+```
+ 
 ---
 
 To customize validation message, add `enum` key to validation lang file

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -91,10 +91,22 @@ abstract class Enum extends MyCLabsEnum
     }
 
     /**
-     * Returns validation rule.
+     * Returns the validation rule (to validate by value).
+     *
+     * @return EnumRule
      */
     public static function rule(): EnumRule
     {
-        return new EnumRule(static::class);
+        return new EnumRule(static::class, false);
+    }
+
+    /**
+     * Returns the validation rule (to validate by key).
+     *
+     * @return EnumRule
+     */
+    public static function ruleByKey(): EnumRule
+    {
+        return new EnumRule(static::class, true);
     }
 }

--- a/src/Rules/EnumRule.php
+++ b/src/Rules/EnumRule.php
@@ -11,16 +11,25 @@ class EnumRule implements Rule
     private $enumClass = '';
 
     /**
+     * @var bool true if the the key of the enum should be used to validate against, otherwise the value is used.
+     */
+    private $useKey = false;
+
+    /**
      * Create a new rule instance.
+     *
+     * @param string $enumClass The enum class to create the the rule for
+     * @param bool $useKey true if the enum key should be used to validate against, otherwise the value is used.
      *
      * @return void
      */
-    public function __construct(string $enumClass)
+    public function __construct(string $enumClass, bool $useKey = false)
     {
         if (! is_subclass_of($enumClass, Enum::class)) {
             throw new InvalidArgumentException("Value '$enumClass' is not an enum class");
         }
 
+        $this->useKey = $useKey;
         $this->enumClass = $enumClass;
     }
 
@@ -33,7 +42,7 @@ class EnumRule implements Rule
      */
     public function passes($attribute, $value): bool
     {
-        return call_user_func([$this->enumClass, 'isValid'], $value);
+        return call_user_func([$this->enumClass, $this->useKey ? 'isValidKey' : 'isValid'], $value);
     }
 
     /**

--- a/tests/EnumValidationRuleTest.php
+++ b/tests/EnumValidationRuleTest.php
@@ -23,8 +23,34 @@ class EnumValidationRuleTest extends TestCase
         $this->assertFalse($result);
     }
 
+    /**
+     * @test
+     * @dataProvider validate_provider_passes_with_parameter
+     *
+     * @param $expectedResult the expected outcome
+     * @param $useKey true if the enum key should be used to validate against, otherwise the value is used.
+     * @param $inputValue the input value to test with
+     */
+    public function validate_with_parameter($expectedResult, $useKey, $inputValue)
+    {
+        $result = (new EnumRule(PostStatusEnum::class, $useKey))->passes('', $inputValue);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function validate_provider_passes_with_parameter()
+    {
+        return [
+            [true, false, 'pending'], // Does exists as value
+            [true, true, 'PENDING'], // Does exists as key
+            [false, false, 'invalid'], // Does not exists as value
+            [false, false, 'PENDING'], // Uppercase value does not exist as value
+            [false, true, 'pending'], // Lowercase value does not exist as key
+        ];
+    }
+
     /** @test */
-    public function validation_passes_by_method()
+    public function validation_passes_rule_method()
     {
         $result = PostStatusEnum::rule()->passes('', 'pending');
 
@@ -32,9 +58,25 @@ class EnumValidationRuleTest extends TestCase
     }
 
     /** @test */
-    public function validation_fails_by_method()
+    public function validation_fails_rule_method()
     {
         $result = PostStatusEnum::rule()->passes('', 'invalid');
+
+        $this->assertFalse($result);
+    }
+
+    /** @test */
+    public function validation_passes_rule_by_key_method()
+    {
+        $result = PostStatusEnum::ruleByKey()->passes('', 'PENDING');
+
+        $this->assertTrue($result);
+    }
+
+    /** @test */
+    public function validation_fails_rule_by_key_method()
+    {
+        $result = PostStatusEnum::ruleByKey()->passes('', 'PENDINGINVALID');
 
         $this->assertFalse($result);
     }
@@ -45,5 +87,13 @@ class EnumValidationRuleTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         new EnumRule('InvalidEnumClass');
+    }
+
+    /** @test */
+    public function exception_on_invalid_enum_class_with_use_key_parameter()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new EnumRule('InvalidEnumClass', true);
     }
 }


### PR DESCRIPTION
## Description
Add support to the validation rule to validate the enum key instead of the enum value.

## Motivation and context
If you use a enum to represent integer values you might one use the enum key instead of the enum value for better understanding.

For example when status of an object is stored as a integer in the database and we use a enum to represent the status, like PullRequestExampleStatus. 

```php
final class PullRequestExampleStatus extends Enum
{
    const __default = self::INACTIVE;

    const INACTIVE = 0;
    const ACTIVE = 1;
    const EXPIRED = 2;
}
```
Using the enum key instead of the enum value in a request clarifies the value you are submitting.

By default the validation rule validates the value instead of the key for backward compatibility.

## How has this been tested?

Unit tests are added.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)