### PR TITLE
Add support for integers as enum values, while using EnumCastable

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ $post->status = PostStatusEnum::PENDING();
 $post->save();
 ```
 
+If you use enum values of type integer with Eloquent models you could add the `CastToIntegerConstructor` trait in the
+Enum class to convert string representations of the integer to the corresponding enum. Depending on the database driver
+used integers might te returned as strings instead of integer.
+
 ### Enum values labels (Localization)
 
 Create `enums.php` lang file and declare labels for enum values

--- a/src/CastToIntegerConstructor.php
+++ b/src/CastToIntegerConstructor.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace MadWeb\Enum;
+
+/**
+ * Trait CastToIntegerConstructor to support using a string as value to create the enum, while the enum value is an
+ * integer.
+ *
+ * This trait solves the issue the Enum cannot be constructed in EnumCastable used in a model while using a integer enum
+ * value. Some database drivers return integers as integer while other returns them as string.
+ *
+ * For example the PHP MySQL native driver return integers, while other drivers return strings.
+ * See the issue https://github.com/laravel/framework/issues/11780 which describes this as well.
+ *
+ * Please note it's not recommended to use constructors in traits, since constructors should be specific to a class to
+ * which they belong. Another solution can be to add a boolean castToInteger on the enum class.
+ */
+trait CastToIntegerConstructor
+{
+    /**
+     * Creates a new value of some type, with casting the supplied value to an integer if the value is present in a
+     * non-strict comparison with the values.
+     *
+     * @param mixed $value
+     *
+     * @throws \UnexpectedValueException if incompatible type is given.
+     */
+    public function __construct($value = null)
+    {
+        // Use the default value when no value is supplied, this cannot be omitted due to
+        // non-strict comparison null == 0, resulting in the integer 0.
+        if (is_null($value)) {
+            $value = static::__default;
+        }
+
+        // Verify the supplied value is present when we don't check for the type.
+        if (\in_array($value, static::toArray(), false)) {
+            $value = (int) $value;
+        }
+
+        parent::__construct($value);
+    }
+}

--- a/tests/DaysOfWeekEnum.php
+++ b/tests/DaysOfWeekEnum.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MadWeb\Enum\Test;
+
+use MadWeb\Enum\Enum;
+use MadWeb\Enum\CastToIntegerConstructor;
+
+final class DaysOfWeekEnum extends Enum
+{
+    use CastToIntegerConstructor;
+
+    // For unit-test purpose the default is not set to sunday, to test null as input results in actual default value and
+    // not due to a non-strict comparison null == 0
+    const __default = self::MONDAY;
+
+    const SUNDAY = 0;
+    const MONDAY = 1;
+    const TUESDAY = 2;
+    const WEDNESDAY = 3;
+    const THURSDAY = 4;
+    const FRIDAY = 5;
+    const SATURDAY = 6;
+}

--- a/tests/EnumCastingTest.php
+++ b/tests/EnumCastingTest.php
@@ -17,11 +17,47 @@ class EnumCastingTest extends TestCase
     }
 
     /** @test */
+    public function retrieve_casting_integer()
+    {
+        $favoriteDay = FavoriteDay::create(['title' => 'Some title', 'day' => 1]);
+
+        $favoriteDay = FavoriteDay::where('id', $favoriteDay->id)->first();
+
+        $this->assertInstanceOf(Enum::class, $favoriteDay->day);
+    }
+
+    /** @test */
+    public function retrieve_casting_integer_as_string()
+    {
+        $favoriteDay = FavoriteDay::create(['title' => 'Some title', 'day' => '1']);
+
+        $favoriteDay = FavoriteDay::where('id', $favoriteDay->id)->first();
+
+        $this->assertInstanceOf(Enum::class, $favoriteDay->day);
+    }
+
+    /** @test */
     public function set_casting()
     {
         $post = Post::make(['title' => 'Some title', 'status' => 'pending']);
 
         $this->assertInstanceOf(Enum::class, $post->status);
+    }
+
+    /** @test */
+    public function set_casting_integer()
+    {
+        $favoriteDay = FavoriteDay::make(['title' => 'Some title', 'day' => 1]);
+
+        $this->assertInstanceOf(Enum::class, $favoriteDay->day);
+    }
+
+    /** @test */
+    public function set_casting_integer_as_string()
+    {
+        $favoriteDay = FavoriteDay::make(['title' => 'Some title', 'day' => '1']);
+
+        $this->assertInstanceOf(Enum::class, $favoriteDay->day);
     }
 
     /** @test */
@@ -32,6 +68,26 @@ class EnumCastingTest extends TestCase
         $post->status = PostStatusEnum::PUBLISHED();
 
         $this->assertEquals($post->status->getValue(), PostStatusEnum::PUBLISHED()->getValue());
+    }
+
+    /** @test */
+    public function set_attribute_integer()
+    {
+        $favoriteDay = FavoriteDay::create(['title' => 'Some title', 'day' => 1]);
+
+        $favoriteDay->day = DaysOfWeekEnum::TUESDAY();
+
+        $this->assertEquals($favoriteDay->day->getValue(), DaysOfWeekEnum::TUESDAY()->getValue());
+    }
+
+    /** @test */
+    public function set_attribute_integer_as_string()
+    {
+        $favoriteDay = FavoriteDay::create(['title' => 'Some title', 'day' => '1']);
+
+        $favoriteDay->day = DaysOfWeekEnum::TUESDAY();
+
+        $this->assertEquals($favoriteDay->day->getValue(), DaysOfWeekEnum::TUESDAY()->getValue());
     }
 
     /** @test */
@@ -46,5 +102,33 @@ class EnumCastingTest extends TestCase
         $post = Post::where('id', $post->id)->first();
 
         $this->assertEquals($post->status->getValue(), PostStatusEnum::PUBLISHED()->getValue());
+    }
+
+    /** @test */
+    public function change_attribute_integer()
+    {
+        $favoriteDay = FavoriteDay::create(['title' => 'Some title', 'day' => 1]);
+
+        $favoriteDay->day = DaysOfWeekEnum::TUESDAY();
+
+        $favoriteDay->save();
+
+        $favoriteDay = FavoriteDay::where('id', $favoriteDay->id)->first();
+
+        $this->assertEquals($favoriteDay->day->getValue(), DaysOfWeekEnum::TUESDAY()->getValue());
+    }
+
+    /** @test */
+    public function change_attribute_integer_as_string()
+    {
+        $favoriteDay = FavoriteDay::create(['title' => 'Some title', 'day' => '1']);
+
+        $favoriteDay->day = DaysOfWeekEnum::TUESDAY();
+
+        $favoriteDay->save();
+
+        $favoriteDay = FavoriteDay::where('id', $favoriteDay->id)->first();
+
+        $this->assertEquals($favoriteDay->day->getValue(), DaysOfWeekEnum::TUESDAY()->getValue());
     }
 }

--- a/tests/EnumClassIntegerTest.php
+++ b/tests/EnumClassIntegerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace MadWeb\Enum\Test;
+
+class EnumClassIntegerTest extends TestCase
+{
+    /** @test */
+    public function default_value()
+    {
+        $Enum = new DaysOfWeekEnum();
+
+        $this->assertEquals($Enum->getValue(), DaysOfWeekEnum::__default);
+    }
+
+    /** @test */
+    public function is()
+    {
+        $Enum = new DaysOfWeekEnum;
+
+        $this->assertTrue($Enum->is(DaysOfWeekEnum::MONDAY));
+    }
+
+    /** @test */
+    public function is_by_object()
+    {
+        $Enum = DaysOfWeekEnum::MONDAY();
+
+        $this->assertTrue($Enum->is(new DaysOfWeekEnum));
+    }
+
+    /** @test */
+    public function values()
+    {
+        $this->assertEquals(
+            [
+                'SUNDAY' => DaysOfWeekEnum::SUNDAY(),
+                'MONDAY' => DaysOfWeekEnum::MONDAY(),
+                'TUESDAY' => DaysOfWeekEnum::TUESDAY(),
+                'WEDNESDAY' => DaysOfWeekEnum::WEDNESDAY(),
+                'THURSDAY' => DaysOfWeekEnum::THURSDAY(),
+                'FRIDAY' => DaysOfWeekEnum::FRIDAY(),
+                'SATURDAY' => DaysOfWeekEnum::SATURDAY(),
+            ],
+            DaysOfWeekEnum::values()
+        );
+    }
+
+    /** @test */
+    public function keys()
+    {
+        $this->assertSame(
+            [
+                'SUNDAY',
+                'MONDAY',
+                'TUESDAY',
+                'WEDNESDAY',
+                'THURSDAY',
+                'FRIDAY',
+                'SATURDAY',
+            ],
+            DaysOfWeekEnum::keys()
+        );
+    }
+
+    /** @test */
+    public function random_value()
+    {
+        $value = DaysOfWeekEnum::randomValue();
+
+        $this->assertContains($value, DaysOfWeekEnum::values());
+    }
+
+    /** @test */
+    public function random_key()
+    {
+        $value = DaysOfWeekEnum::randomKey();
+
+        $this->assertContains($value, DaysOfWeekEnum::keys());
+    }
+
+    /** @test */
+    public function get_constants_list()
+    {
+        $this->assertSame(
+            [
+                'SUNDAY' => 0,
+                'MONDAY' => 1,
+                'TUESDAY' => 2,
+                'WEDNESDAY' => 3,
+                'THURSDAY' => 4,
+                'FRIDAY' => 5,
+                'SATURDAY' => 6,
+            ],
+            (new DaysOfWeekEnum)->getConstList()
+        );
+    }
+
+    /** @test */
+    public function get_constants_list_with_default()
+    {
+        $this->assertSame(
+            [
+                '__default' => 1,
+                'SUNDAY' => 0,
+                'MONDAY' => 1,
+                'TUESDAY' => 2,
+                'WEDNESDAY' => 3,
+                'THURSDAY' => 4,
+                'FRIDAY' => 5,
+                'SATURDAY' => 6,
+            ],
+            (new DaysOfWeekEnum)->getConstList(true)
+        );
+    }
+}

--- a/tests/FavoriteDay.php
+++ b/tests/FavoriteDay.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MadWeb\Enum\Test;
+
+use MadWeb\Enum\EnumCastable;
+use Illuminate\Database\Eloquent\Model;
+
+class FavoriteDay extends Model
+{
+    use EnumCastable;
+
+    public $timestamps = false;
+
+    protected $fillable = ['title', 'day'];
+
+    protected $casts = [
+        'day' => DaysOfWeekEnum::class,
+    ];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -61,5 +61,11 @@ class TestCase extends OrchestraTestCase
             $table->string('title');
             $table->string('status');
         });
+
+        $app['db']->connection()->getSchemaBuilder()->create('favorite_days', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->integer('day');
+        });
     }
 }


### PR DESCRIPTION
## Description
This pull request fixes the issue enums using integer values can not be constructed while using `EmumCastable` in a Eloquent model.

## Motivation and context
The `EmumCastable` trait tries to cast values to their corresponding Enum value. While fetching a Eloquent model the attributes retrieved from the database are stored as raw attributes. Depending on the database driver used integers might be returned as strings while other returns them as integers. For example the mysqlnd driver returns integers as integer while sqlite returns string.

If the enum uses integers the retrieved integer as string cannot be casted to an enum value due to a type mismatch, resulting in a UnexpectedValueException

```php
    public function __construct($value)
    {
        if (!$this->isValid($value)) {
            throw new \UnexpectedValueException("Value '$value' is not part of the enum " . \get_called_class());
        }
```
The permanent link to the code snippet:

https://github.com/myclabs/php-enum/blob/a8284c7c540caf9988e339a404cadcdf1e8b165d/src/Enum.php#L41-L45

To fix the issue I first checked whether the EnumCastable trait can be changed, but doesn't work since we need to support enums with and without integer values.

Instead I've created a trait for reuse in several enums. But please note using constructors in traits is not recommended, since constructors should be specific to a class to which they belong.
Another solution can be to add a protected boolean castToInteger on the enum class and override when needed in the particular enum class. The constructor in the `MadWeb\Enum\Enum` can check for the castToInteger value.

I imagine enums are mainly used with strings and integers.

Let me know whether you want to use the trait, change `MadWeb\Enum\Enum` or another solution ;-)
So I can update the PR.

The change to the constructor has no effect on the validation rules since these are using the constants defined in the enum.

## How has this been tested?
Added several unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
