### PR TITLE
Fix bug in method Enum::toArray 

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -75,7 +75,7 @@ abstract class Enum extends MyCLabsEnum
     {
         $result = parent::toArray();
 
-        if (isset($result['__default']) and ! $include_default) {
+        if (! $include_default) {
             unset($result['__default']);
         }
 

--- a/tests/EnumClassTest.php
+++ b/tests/EnumClassTest.php
@@ -96,4 +96,15 @@ class EnumClassTest extends TestCase
             (new PostStatusEnum)->getConstList(true)
         );
     }
+
+    /** @test */
+    public function to_array_without_defalut()
+    {
+        $this->assertSame(
+            [
+                'FOO' => 'foo',
+            ],
+            WithoutDefaultEnum::toArray(false)
+        );
+    }
 }

--- a/tests/WithoutDefaultEnum.php
+++ b/tests/WithoutDefaultEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MadWeb\Enum\Test;
+
+use MadWeb\Enum\Enum;
+
+final class WithoutDefaultEnum extends Enum
+{
+    const FOO = 'foo';
+}


### PR DESCRIPTION
## Description

If the inherited class does not define a property `__default`, then the method `Enum::toArray(false)` will return an unexpected result:

```
[
   '__default' => null,
   'FOO' => 'foo',
]
```

## Motivation and context

Fix this

## How has this been tested?

Add test `\MadWeb\Enum\Test\EnumClassTest::to_array_without_defalut`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

