### PR TITLE
Allow passing values to make:enum command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Make new Enum class via artisan command
 php artisan make:enum PostStatusEnum
 ```
 
+or to populate with your own values
+
+```bash
+php artisan make:enum PostStatusEnum DRAFT=draft PENDING=pending PUBLISHED=published
+```
+
 Create instance of Enum class
 
 ``` php

--- a/src/Console/EnumMakeCommand.php
+++ b/src/Console/EnumMakeCommand.php
@@ -76,7 +76,7 @@ class EnumMakeCommand extends GeneratorCommand
     protected function getArguments()
     {
         return array_merge(parent::getArguments(), [
-          ['values', InputArgument::IS_ARRAY, 'The const maps e.g. ACTIVE=active DELETED=deleted; or FOO BAR BAZ for FOO=0 BAR=1 BAZ=2']
+          ['values', InputArgument::IS_ARRAY, 'The const maps e.g. ACTIVE=active DELETED=deleted; or FOO BAR BAZ for FOO=0 BAR=1 BAZ=2'],
         ]);
     }
 

--- a/src/Console/EnumMakeCommand.php
+++ b/src/Console/EnumMakeCommand.php
@@ -3,6 +3,7 @@
 namespace MadWeb\Enum\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputArgument;
 
 class EnumMakeCommand extends GeneratorCommand
 {
@@ -47,5 +48,96 @@ class EnumMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Enums';
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+
+        return $this
+          ->replaceDocblock($stub)
+          ->replaceConstants($stub)
+          ->replaceNamespace($stub, $name)
+          ->replaceClass($stub, $name);
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return array_merge(parent::getArguments(), [
+          ['values', InputArgument::IS_ARRAY, 'The const maps e.g. ACTIVE=active DELETED=deleted; or FOO BAR BAZ for FOO=0 BAR=1 BAZ=2']
+        ]);
+    }
+
+    /**
+     * Get the constants for the enum.
+     *
+     * @return array
+     */
+    protected function getConstants()
+    {
+        $inputValues = $this->argument('values');
+        if (empty($inputValues)) {
+            $inputValues = ['FOO', 'BAR', 'BAZ'];
+        }
+
+        $outputValues = [];
+        $mapIndex = 0;
+
+        foreach ($inputValues as $inputValue) {
+            $parts = explode('=', $inputValue);
+            $outputValues[$parts[0]] = ($parts[1] ?? $mapIndex++);
+        }
+
+        return $outputValues;
+    }
+
+    /**
+     * Replace the docblock for the given stub.
+     *
+     * @param string $stub
+     *
+     * @return $this
+     */
+    protected function replaceDocblock(&$stub)
+    {
+        $docBlock = [];
+        foreach ($this->getConstants() as $const => $value) {
+            $docBlock[] = " * @method static DummyClass {$const}()";
+        }
+
+        $stub = str_replace('DOCBLOCK', implode(PHP_EOL, $docBlock), $stub);
+
+        return $this;
+    }
+
+    /**
+     * Replace the constants for the given stub.
+     *
+     * @param string $stub
+     *
+     * @return $this
+     */
+    protected function replaceConstants(&$stub)
+    {
+        $constList = [];
+        foreach ($this->getConstants() as $const => $value) {
+            $constList[] = is_int($value) ? "    const {$const} = {$value};" : "    const {$const} = '{$value}';";
+        }
+
+        $stub = str_replace(['DEFAULTVALUE', 'CONSTLIST'], [array_keys($this->getConstants())[0], implode(PHP_EOL, $constList)], $stub);
+
+        return $this;
     }
 }

--- a/src/Console/stubs/enum.stub
+++ b/src/Console/stubs/enum.stub
@@ -5,15 +5,11 @@ namespace DummyNamespace;
 use MadWeb\Enum\Enum;
 
 /**
- * @method static DummyClass FOO()
- * @method static DummyClass BAR()
- * @method static DummyClass BAZ()
+DOCBLOCK
  */
 final class DummyClass extends Enum
 {
-    const __default = self::FOO;
+    const __default = self::DEFAULTVALUE;
 
-    const FOO = 0;
-    const BAR = 1;
-    const BAZ = 2;
+CONSTLIST
 }

--- a/tests/EnumMakeCommandTest.php
+++ b/tests/EnumMakeCommandTest.php
@@ -3,21 +3,53 @@
 namespace MadWeb\Enum\Test;
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
 
 class EnumMakeCommandTest extends TestCase
 {
     public $mockConsoleOutput = false;
 
-    /** @test */
-    public function make_command()
+    protected function tearDown()
     {
-        $exitCode = $this->artisan('make:enum', ['name' => 'TestEnum']);
+        File::deleteDirectory($this->app->basePath('app/Enums'));
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     * @dataProvider makeCommandDataProvider
+     */
+    public function make_command($arguments)
+    {
+        $exitCode = $this->artisan('make:enum', $arguments);
 
         $this->assertEquals(0, $exitCode);
         $this->assertContains('Enum created successfully', Artisan::output());
-        $this->assertFileExists($this->app->basePath('app/Enums/TestEnum.php'));
+        $this->assertFileExists($this->app->basePath("app/Enums/{$arguments['name']}.php"));
+        $this->assertFileEquals(
+            __DIR__ . "/fixtures/{$arguments['name']}.php",
+            $this->app->basePath("app/Enums/{$arguments['name']}.php")
+        );
+    }
 
-        unlink($this->app->basePath('app/Enums/TestEnum.php'));
-        rmdir($this->app->basePath('app/Enums'));
+    public function makeCommandDataProvider()
+    {
+        return [
+            [[
+                'name' => 'MyEnumNoArguments']
+            ],
+            [[
+                'name' => 'MyEnumValuelessArguments',
+                'values' => ['SMALL', 'MEDIUM', 'LARGE']
+            ]],
+            [[
+                'name' => 'MyEnumValuedArguments',
+                'values' => ['SMALL=s', 'MEDIUM=m', 'LARGE=l']
+            ]],
+            [[
+                'name' => 'MyEnumMixedValueValuelessArguments',
+                'values' => ['WITH1=with1', 'WITHOUT1', 'WITH2=with2', 'WITHOUT2', 'WITHOUT3', 'WITH3=with3']
+            ]],
+        ];
     }
 }

--- a/tests/EnumMakeCommandTest.php
+++ b/tests/EnumMakeCommandTest.php
@@ -2,8 +2,8 @@
 
 namespace MadWeb\Enum\Test;
 
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Artisan;
 
 class EnumMakeCommandTest extends TestCase
 {
@@ -27,7 +27,7 @@ class EnumMakeCommandTest extends TestCase
         $this->assertContains('Enum created successfully', Artisan::output());
         $this->assertFileExists($this->app->basePath("app/Enums/{$arguments['name']}.php"));
         $this->assertFileEquals(
-            __DIR__ . "/fixtures/{$arguments['name']}.php",
+            __DIR__."/fixtures/{$arguments['name']}.php",
             $this->app->basePath("app/Enums/{$arguments['name']}.php")
         );
     }
@@ -36,19 +36,19 @@ class EnumMakeCommandTest extends TestCase
     {
         return [
             [[
-                'name' => 'MyEnumNoArguments']
-            ],
+                'name' => 'MyEnumNoArguments',
+            ]],
             [[
                 'name' => 'MyEnumValuelessArguments',
-                'values' => ['SMALL', 'MEDIUM', 'LARGE']
+                'values' => ['SMALL', 'MEDIUM', 'LARGE'],
             ]],
             [[
                 'name' => 'MyEnumValuedArguments',
-                'values' => ['SMALL=s', 'MEDIUM=m', 'LARGE=l']
+                'values' => ['SMALL=s', 'MEDIUM=m', 'LARGE=l'],
             ]],
             [[
                 'name' => 'MyEnumMixedValueValuelessArguments',
-                'values' => ['WITH1=with1', 'WITHOUT1', 'WITH2=with2', 'WITHOUT2', 'WITHOUT3', 'WITH3=with3']
+                'values' => ['WITH1=with1', 'WITHOUT1', 'WITH2=with2', 'WITHOUT2', 'WITHOUT3', 'WITH3=with3'],
             ]],
         ];
     }

--- a/tests/fixtures/MyEnumMixedValueValuelessArguments.php
+++ b/tests/fixtures/MyEnumMixedValueValuelessArguments.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Enums;
+
+use MadWeb\Enum\Enum;
+
+/**
+ * @method static MyEnumMixedValueValuelessArguments WITH1()
+ * @method static MyEnumMixedValueValuelessArguments WITHOUT1()
+ * @method static MyEnumMixedValueValuelessArguments WITH2()
+ * @method static MyEnumMixedValueValuelessArguments WITHOUT2()
+ * @method static MyEnumMixedValueValuelessArguments WITHOUT3()
+ * @method static MyEnumMixedValueValuelessArguments WITH3()
+ */
+final class MyEnumMixedValueValuelessArguments extends Enum
+{
+    const __default = self::WITH1;
+
+    const WITH1 = 'with1';
+    const WITHOUT1 = 0;
+    const WITH2 = 'with2';
+    const WITHOUT2 = 1;
+    const WITHOUT3 = 2;
+    const WITH3 = 'with3';
+}

--- a/tests/fixtures/MyEnumNoArguments.php
+++ b/tests/fixtures/MyEnumNoArguments.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+use MadWeb\Enum\Enum;
+
+/**
+ * @method static MyEnumNoArguments FOO()
+ * @method static MyEnumNoArguments BAR()
+ * @method static MyEnumNoArguments BAZ()
+ */
+final class MyEnumNoArguments extends Enum
+{
+    const __default = self::FOO;
+
+    const FOO = 0;
+    const BAR = 1;
+    const BAZ = 2;
+}

--- a/tests/fixtures/MyEnumValuedArguments.php
+++ b/tests/fixtures/MyEnumValuedArguments.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+use MadWeb\Enum\Enum;
+
+/**
+ * @method static MyEnumValuedArguments SMALL()
+ * @method static MyEnumValuedArguments MEDIUM()
+ * @method static MyEnumValuedArguments LARGE()
+ */
+final class MyEnumValuedArguments extends Enum
+{
+    const __default = self::SMALL;
+
+    const SMALL = 's';
+    const MEDIUM = 'm';
+    const LARGE = 'l';
+}

--- a/tests/fixtures/MyEnumValuelessArguments.php
+++ b/tests/fixtures/MyEnumValuelessArguments.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+use MadWeb\Enum\Enum;
+
+/**
+ * @method static MyEnumValuelessArguments SMALL()
+ * @method static MyEnumValuelessArguments MEDIUM()
+ * @method static MyEnumValuelessArguments LARGE()
+ */
+final class MyEnumValuelessArguments extends Enum
+{
+    const __default = self::SMALL;
+
+    const SMALL = 0;
+    const MEDIUM = 1;
+    const LARGE = 2;
+}


### PR DESCRIPTION
## Description

Allows a user to provide values to populate the enum stub rather than the fixed FOO BAR BAZ

Below are some examples of output

Command:
```bash
php artisan make:enum MyEnum
```

Output:
```php
<?php

namespace App\Enums;

use MadWeb\Enum\Enum;

/**
 * @method static MyEnum FOO()
 * @method static MyEnum BAR()
 * @method static MyEnum BAZ()
 */
final class MyEnum extends Enum
{
    const __default = self::FOO;

    const FOO = 0;
    const BAR = 1;
    const BAZ = 2;
}
```

Command:
```bash
php artisan make:enum MyEnum SMALL MEDIUM LARGE
```

Output:
```php
<?php

namespace App\Enums;

use MadWeb\Enum\Enum;

/**
 * @method static MyEnum SMALL()
 * @method static MyEnum MEDIUM()
 * @method static MyEnum LARGE()
 */
final class MyEnum extends Enum
{
    const __default = self::SMALL;

    const SMALL = 0;
    const MEDIUM = 1;
    const LARGE = 2;
}
```

Command:
```bash
php artisan make:enum MyEnum SMALL=s MEDIUM=m LARGE=l
```

Output:
```php
<?php

namespace App\Enums;

use MadWeb\Enum\Enum;

/**
 * @method static MyEnum SMALL()
 * @method static MyEnum MEDIUM()
 * @method static MyEnum LARGE()
 */
final class MyEnum extends Enum
{
    const __default = self::SMALL;

    const SMALL = 's';
    const MEDIUM = 'm';
    const LARGE = 'l';
}
```

Command:
```bash
php artisan make:enum MyEnum WITH1=with1 WITHOUT1 WITH2=with2 WITHOUT2 WITHOUT3 WITH3=with3
```

Output:
```php
<?php

namespace App\Enums;

use MadWeb\Enum\Enum;

/**
 * @method static MyEnum WITH1()
 * @method static MyEnum WITHOUT1()
 * @method static MyEnum WITH2()
 * @method static MyEnum WITHOUT2()
 * @method static MyEnum WITHOUT3()
 * @method static MyEnum WITH3()
 */
final class MyEnum extends Enum
{
    const __default = self::WITH1;

    const WITH1 = 'with1';
    const WITHOUT1 = 0;
    const WITH2 = 'with2';
    const WITHOUT2 = 1;
    const WITHOUT3 = 2;
    const WITH3 = 'with3';
}

```

## Motivation and context

It's a pain having to generate the file and then wipe out the boilerplate to add your own.
This makes scaffolding much quicker

## How has this been tested?
Manual testing as shown above. I looked at adding an actual output test, but since the default command did not have this I have not added it.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes. (Irrelevant)
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
