### PR TITLE
Add constant visibility for PSR-12 compatiblity

### DIFF
--- a/src/Console/EnumMakeCommand.php
+++ b/src/Console/EnumMakeCommand.php
@@ -133,7 +133,7 @@ class EnumMakeCommand extends GeneratorCommand
     {
         $constList = [];
         foreach ($this->getConstants() as $const => $value) {
-            $constList[] = is_int($value) ? "    const {$const} = {$value};" : "    const {$const} = '{$value}';";
+            $constList[] = is_int($value) ? "    public const {$const} = {$value};" : "    public const {$const} = '{$value}';";
         }
 
         $stub = str_replace(['DEFAULTVALUE', 'CONSTLIST'], [array_keys($this->getConstants())[0], implode(PHP_EOL, $constList)], $stub);

--- a/src/Console/stubs/enum.stub
+++ b/src/Console/stubs/enum.stub
@@ -9,7 +9,7 @@ DOCBLOCK
  */
 final class DummyClass extends Enum
 {
-    const __default = self::DEFAULTVALUE;
+    public const __default = self::DEFAULTVALUE;
 
 CONSTLIST
 }

--- a/tests/fixtures/MyEnumMixedValueValuelessArguments.php
+++ b/tests/fixtures/MyEnumMixedValueValuelessArguments.php
@@ -14,12 +14,12 @@ use MadWeb\Enum\Enum;
  */
 final class MyEnumMixedValueValuelessArguments extends Enum
 {
-    const __default = self::WITH1;
+    public const __default = self::WITH1;
 
-    const WITH1 = 'with1';
-    const WITHOUT1 = 0;
-    const WITH2 = 'with2';
-    const WITHOUT2 = 1;
-    const WITHOUT3 = 2;
-    const WITH3 = 'with3';
+    public const WITH1 = 'with1';
+    public const WITHOUT1 = 0;
+    public const WITH2 = 'with2';
+    public const WITHOUT2 = 1;
+    public const WITHOUT3 = 2;
+    public const WITH3 = 'with3';
 }

--- a/tests/fixtures/MyEnumNoArguments.php
+++ b/tests/fixtures/MyEnumNoArguments.php
@@ -11,9 +11,9 @@ use MadWeb\Enum\Enum;
  */
 final class MyEnumNoArguments extends Enum
 {
-    const __default = self::FOO;
+    public const __default = self::FOO;
 
-    const FOO = 0;
-    const BAR = 1;
-    const BAZ = 2;
+    public const FOO = 0;
+    public const BAR = 1;
+    public const BAZ = 2;
 }

--- a/tests/fixtures/MyEnumValuedArguments.php
+++ b/tests/fixtures/MyEnumValuedArguments.php
@@ -11,9 +11,9 @@ use MadWeb\Enum\Enum;
  */
 final class MyEnumValuedArguments extends Enum
 {
-    const __default = self::SMALL;
+    public const __default = self::SMALL;
 
-    const SMALL = 's';
-    const MEDIUM = 'm';
-    const LARGE = 'l';
+    public const SMALL = 's';
+    public const MEDIUM = 'm';
+    public const LARGE = 'l';
 }

--- a/tests/fixtures/MyEnumValuelessArguments.php
+++ b/tests/fixtures/MyEnumValuelessArguments.php
@@ -11,9 +11,9 @@ use MadWeb\Enum\Enum;
  */
 final class MyEnumValuelessArguments extends Enum
 {
-    const __default = self::SMALL;
+    public const __default = self::SMALL;
 
-    const SMALL = 0;
-    const MEDIUM = 1;
-    const LARGE = 2;
+    public const SMALL = 0;
+    public const MEDIUM = 1;
+    public const LARGE = 2;
 }


### PR DESCRIPTION
## Description

Makes the enum:make command add the `public` visibility keyword to all generated constants.

## Motivation and context

https://www.php-fig.org/psr/psr-12/#43-properties-and-constants

## How has this been tested?

Updated test cases

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [ ] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
